### PR TITLE
Allow to use remote PostgreSQL database

### DIFF
--- a/recipes/_postgresql.rb
+++ b/recipes/_postgresql.rb
@@ -5,15 +5,18 @@
 # Installs PostgreSQL and creates database
 #
 
-# Install PostgreSQL server and client
-include_recipe "postgresql::server"
+db = node["practicingruby"]["database"]
+
+# Install PostgreSQL server if database is local
+include_recipe "postgresql::server" if db["host"] == "localhost"
+
+# Install PostgreSQL client
 include_recipe "postgresql::client"
 
 # Make postgresql_database resource available
 include_recipe "database::postgresql"
 
 # Create database for Rails app
-db = node["practicingruby"]["database"]
 postgresql_database db["name"] do
   connection(
     :host     => db["host"],


### PR DESCRIPTION
With this small change, we can use an external PostgreSQL database.

For example, I managed to connect to an external [RDS instance in AWS](http://aws.amazon.com/rds/postgresql/) only by overriding `node["practicingruby"]["database"]["host"]`. The remaining bits are handled by Chef/Capistrano/Rails as usual.

```
$ psql -l --host=mathias-postgres-test.xxx.eu-west-1.rds.amazonaws.com --username=postgres
Password for user postgres:
                                          List of databases
            Name            |  Owner   | Encoding |   Collate   |    Ctype    |   Access privileges
----------------------------+----------+----------+-------------+-------------+-----------------------
 postgres                   | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 |
 practicing-ruby-production | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 |
 rdsadmin                   | rdsadmin | UTF8     | en_US.UTF-8 | en_US.UTF-8 | rdsadmin=CTc/rdsadmin
 template0                  | rdsadmin | UTF8     | en_US.UTF-8 | en_US.UTF-8 | =c/rdsadmin          +
                            |          |          |             |             | rdsadmin=CTc/rdsadmin
 template1                  | postgres | UTF8     | en_US.UTF-8 | en_US.UTF-8 | =c/postgres          +
                            |          |          |             |             | postgres=CTc/postgres
(5 rows)
```
