### PR TITLE
Fix the Pygments package's name

### DIFF
--- a/test/integration/default/serverspec/rails_spec.rb
+++ b/test/integration/default/serverspec/rails_spec.rb
@@ -8,7 +8,7 @@ describe "practicingruby::_rails" do
   end
 
   it "installs Pygments for syntax highlighting" do
-    expect(package "nodejs").to be_installed
+    expect(package "python-pygments").to be_installed
   end
 
   it "installs Nokogiri dependencies" do


### PR DESCRIPTION
The package name seemed to be wrong.
Maybe a copy&paste thing. It happens to me all the time.
