### PR TITLE
WIP: Ubuntu 14.04 LTS

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,11 +7,13 @@ provisioner:
   require_chef_omnibus: 11.12.8
 
 platforms:
-  - name: ubuntu-12.04
+  - name: trusty64
     driver:
+      box: ubuntu/trusty64
+      box_url: https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box
       customize:
-        memory: 768
-        cpus: 1
+        memory: 2048
+        cpus: 2
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,13 +4,13 @@ driver:
 
 provisioner:
   name: chef_solo
-  require_chef_omnibus: 11.12.8
+  require_chef_omnibus: 11.16.4
 
 platforms:
-  - name: trusty64
+  - name: ubuntu-14.04
     driver:
       box: ubuntu/trusty64
-      box_url: https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box
+      box_url: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
       customize:
         memory: 2048
         cpus: 2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The cookbook was originally built for the Practicing Ruby article
 To use this cookbook, you need the following software:
 
 * [VirtualBox] - Version 4.2 or higher
-* [Vagrant] - Version 1.3.4 or higher
+* [Vagrant] - Version 1.5 or higher
 * [vagrant-omnibus] - installable via `vagrant plugin install vagrant-omnibus`
 * [Berkshelf] - installable via `bundle install`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,8 @@ Vagrant.configure("2") do |config|
 
   # Mirror specs of production system
   config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--memory", 768]
-    v.customize ["modifyvm", :id, "--cpus", 1]
+    v.customize ["modifyvm", :id, "--memory", 2048]
+    v.customize ["modifyvm", :id, "--cpus", 2]
   end
 
   unless ENV["VAGRANT_NO_PLUGINS"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,8 @@ def abspath(f)
 end
 
 Vagrant.configure("2") do |config|
-  # VM will be based on Ubuntu 12.04 (64 bit)
-  config.vm.box      = "ubuntu-12.04"
-  config.vm.box_url  = "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box"
+  # VM will be based on Ubuntu 14.04 LTS (64 bit)
+  config.vm.box = "ubuntu/trusty64"
 
   # Set a nice hostname
   config.vm.hostname = "practicingruby"

--- a/test/integration/default/serverspec/postgresql_spec.rb
+++ b/test/integration/default/serverspec/postgresql_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "practicingruby::_postgresql" do
-  let(:postgresql_version) { "9.1" }
+  let(:postgresql_version) { "9.3" }
   let(:postgresql_port) { 5432 }
 
   it "installs PostgreSQL server" do
@@ -13,7 +13,7 @@ describe "practicingruby::_postgresql" do
   end
 
   it "starts PostgreSQL server" do
-    output = "Running clusters: #{postgresql_version}/main"
+    output = "#{postgresql_version}/main (port #{postgresql_port}): online"
     expect(command "service postgresql status").to return_stdout output
     expect(port postgresql_port).to be_listening
   end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,10 +1,4 @@
 require "serverspec"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/sbin:/usr/sbin:$PATH"


### PR DESCRIPTION
This updates the cookbook to use a new Vagrant box running Ubuntu 14.04 LTS.

Package updates include:
- Nginx 1.4.6
- PostgreSQL 9.3.4
- Ruby 2.1.1-p76 (could not install 2.0 as default Ruby due to https://bugs.launchpad.net/ubuntu/+source/ruby2.0/+bug/1310292)

Note that the new VM works best with **2 GB of RAM and 2 CPUs**, which is much more compared to Ubuntu 12.04.

TODO:
- [x] Wait for https://github.com/hw-cookbooks/postgresql/pull/125 to be merged upstream
- [x] Update Test-Kitchen and integration tests
- [ ] Figure out why `service nginx status` reports the wrong result after provisioning -> turned out to be a problem with the nginx cookbook, tested that installing nginx manually works fine
